### PR TITLE
DoD DISA 2.3 - remove setuid/setgid from any binary that not strictly requires it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   repository_dispatch:
     types:
       - trigger-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
   repository_dispatch:
     types:
       - trigger-build

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -54,7 +54,7 @@ VOLUME /var/lib/postgresql/data
 RUN mkdir /docker-entrypoint-initdb.d
 
 # DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
-RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+RUN find / -not -path "/proc/*" -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
 
 USER 26
 

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -54,7 +54,7 @@ VOLUME /var/lib/postgresql/data
 RUN mkdir /docker-entrypoint-initdb.d
 
 # DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
-RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+RUN find / -not -path "/proc/*" -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
 
 USER 26
 

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -54,7 +54,7 @@ VOLUME /var/lib/postgresql/data
 RUN mkdir /docker-entrypoint-initdb.d
 
 # DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
-RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+RUN find / -not -path "/proc/*" -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
 
 USER 26
 

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -54,7 +54,7 @@ VOLUME /var/lib/postgresql/data
 RUN mkdir /docker-entrypoint-initdb.d
 
 # DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
-RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+RUN find / -not -path "/proc/*" -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
 
 USER 26
 

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -54,7 +54,7 @@ VOLUME /var/lib/postgresql/data
 RUN mkdir /docker-entrypoint-initdb.d
 
 # DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
-RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+RUN find / -not -path "/proc/*" -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
 
 USER 26
 

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -54,7 +54,7 @@ VOLUME /var/lib/postgresql/data
 RUN mkdir /docker-entrypoint-initdb.d
 
 # DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
-RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+RUN find / -not -path "/proc/*" -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
 
 USER 26
 

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -53,6 +53,9 @@ VOLUME /var/lib/postgresql/data
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# DoD 2.3 - remove setuid/setgid from any binary that not strictly requires it, and before doing that list them on the stdout
+RUN find / -perm /6000 -type f -exec ls -ld {} \; -exec chmod a-s {} \; || true
+
 USER 26
 
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
I've merged dev/cnp-234 here in order to test the images built with by this PR, `workflow_dispatch` trigger can be removed from the Continuous Delivery workflow during merge if not needed anymore.