### PR TITLE
fix(pipeline): Use cnp-autobot to push automatic updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  repository_dispatch:
-    types:
-      - trigger-build
 
 env:
   IMAGE_STAGING: enterprisedb/postgresql-testing

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
       - name: Run update script
         uses: nick-invision/retry@v2.4.1
         with:
@@ -37,12 +39,3 @@ jobs:
           author_name: EnterpriseDB Automated Updates
           author_email: noreply@enterprisedb.com
           message: 'Daily automatic update'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dispatch trigger-e2e event
-        if: steps.commit.outputs.committed == 'true'
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.REPO_GHA_PAT }}
-          repository: ${{ github.repository }}
-          event-type: trigger-build


### PR DESCRIPTION
Now that we have Branch protection rules on main, we must
use cnp-autobot for automatic updates commit.
Also removed an unnecessary step that made the build
worflow trigger twice for the same commit.

Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>