### PR TITLE
fix: python3-setuptools missing during the build process on Debian

### DIFF
--- a/Debian/10/Dockerfile
+++ b/Debian/10/Dockerfile
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/10/Dockerfile.postgis
+++ b/Debian/10/Dockerfile.postgis
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/11/Dockerfile
+++ b/Debian/11/Dockerfile
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/11/Dockerfile.postgis
+++ b/Debian/11/Dockerfile.postgis
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/12/Dockerfile
+++ b/Debian/12/Dockerfile
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/12/Dockerfile.postgis
+++ b/Debian/12/Dockerfile.postgis
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/13/Dockerfile
+++ b/Debian/13/Dockerfile
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/13/Dockerfile.postgis
+++ b/Debian/13/Dockerfile.postgis
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/Dockerfile-debian.template
+++ b/Debian/Dockerfile-debian.template
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \

--- a/Debian/Dockerfile-postgis.template
+++ b/Debian/Dockerfile-postgis.template
@@ -105,6 +105,7 @@ RUN set -xe; \
 	apt-get install -y --no-install-recommends \
 		python3-pip \
 		python3-psycopg2 \
+		python3-setuptools \
 	; \
 	pip3 install --upgrade pip; \
 	pip3 install -r requirements.txt; \


### PR DESCRIPTION
Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>