### PR TITLE
fix: Use new action for dockle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,14 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v2
-      - id: generate-jobs
-        name: Generate Jobs
-        run: .github/generate-strategy.sh
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: GenerateJoibs
+        id: generate-jobs
+        shell: bash
+        run: |
+          bash .github/generate-strategy.sh
 
   build:
     needs: generate-jobs
@@ -76,11 +80,14 @@ jobs:
         labels: ${{ github.ref != 'refs/heads/main' && 'quay.expires-after=7d' || '' }}
 
     - name: Dockle scan
-      uses: hands-lab/dockle-action@v1
+      uses: erzz/dockle-action@v1.1.0
       with:
         image: "quay.io/${{ env.IMAGE_STAGING }}:${{ matrix.tags[0] }}"
         exit-code: '1'
-        exit-level: WARN
+        failure-threshold: WARN
+        dockle-version: 0.4.2
+        accept-filenames: settings.py
+        accept-extensions: pem,pfx,p12,key,asc
       env:
         DOCKLE_USERNAME: ${{ secrets.QUAY_USERNAME }}
         DOCKLE_PASSWORD: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-
-      - name: GenerateJoibs
+      - name: Generate Jobs
         id: generate-jobs
         shell: bash
         run: |
@@ -32,7 +31,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Code
+      uses: actions/checkout@v2
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1.2.0
     - name: Docker meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,7 @@ jobs:
         image: "quay.io/${{ env.IMAGE_STAGING }}:${{ matrix.tags[0] }}"
         exit-code: '1'
         failure-threshold: WARN
-        accept-filenames: settings.py
-        accept-extensions: pem,pfx,p12,key,asc
+        accept-filenames: usr/share/cmake/Templates/Windows/Windows_TemporaryKey.pfx,etc/trusted-key.key,usr/share/doc/perl-IO-Socket-SSL/certs/server_enc.p12,usr/share/doc/perl-IO-Socket-SSL/certs/server.p12,usr/local/lib/python3.8/site-packages/azure/core/settings.py,usr/share/postgresql-common/pgdg/apt.postgresql.org.asc,usr/local/lib/python3.7/dist-packages/azure/core/settings.py,etc/ssl/private/ssl-cert-snakeoil.key
       env:
         DOCKLE_USERNAME: ${{ secrets.QUAY_USERNAME }}
         DOCKLE_PASSWORD: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,12 +80,11 @@ jobs:
         labels: ${{ github.ref != 'refs/heads/main' && 'quay.expires-after=7d' || '' }}
 
     - name: Dockle scan
-      uses: erzz/dockle-action@v1.1.0
+      uses: erzz/dockle-action@v1.1.1
       with:
         image: "quay.io/${{ env.IMAGE_STAGING }}:${{ matrix.tags[0] }}"
         exit-code: '1'
         failure-threshold: WARN
-        dockle-version: 0.4.2
         accept-filenames: settings.py
         accept-extensions: pem,pfx,p12,key,asc
       env:


### PR DESCRIPTION
The current github action `hands-lab/dockle-action` doesn't support
new options to skip some files that match the CIS-DI-0010.

The new action `erzz/dockle-action` supports these options and we
added the needed extensions and file to skip.