### PR TITLE
fix: pin a barman compatible google-api-core release

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,8 +39,7 @@ jobs:
           command: |
             # pip-tools provides pip-compile used by update.sh
             export PATH=$HOME/.local/bin:$PATH
-            # TODO: Remove pip workaround once https://github.com/jazzband/pip-tools/issues/1558 is fixed
-            pip3 install --upgrade pip-tools cloudsmith-cli 'pip<22'
+            pip3 install --upgrade pip-tools cloudsmith-cli pip
             echo "Updating UBI images"
             ./UBI/update.sh
             echo "Updating Debian images"

--- a/Debian/update.sh
+++ b/Debian/update.sh
@@ -217,6 +217,9 @@ update_requirements() {
 	# If there's a new version we need to recreate the requirements files
 	echo "barman[cloud,azure,snappy,google] == $barmanVersion" > requirements.in
 
+	# TODO: Remove once barman removes the `protobuf<3.18` requirement
+	echo "google-api-core <= 2.8.2" >> requirements.in
+
 	# This will take the requirements.in file and generate a file
 	# requirements.txt with the hashes for the required packages
 	pip-compile --generate-hashes 2> /dev/null

--- a/IronBank/update.sh
+++ b/IronBank/update.sh
@@ -223,6 +223,9 @@ update_requirements() {
 	# ugly hack; not very proud of this
 	echo "pip == 21.3.1" >> requirements.in
 
+	# TODO: Remove once barman removes the `protobuf<3.18` requirement
+	echo "google-api-core <= 2.8.2" >> requirements.in
+
 	# This will take the requirements.in file and generate a file
 	# requirements.txt with the hashes for the required packages
 	# --allow-unsafe is used for pip. This gets re-installed to fix crypto/rust issues

--- a/UBI/update.sh
+++ b/UBI/update.sh
@@ -382,6 +382,9 @@ update_requirements() {
 	# If there's a new version we need to recreate the requirements files
 	echo "barman[cloud,azure,snappy,google] == $barmanVersion" > requirements.in
 
+	# TODO: Remove once barman removes the `protobuf<3.18` requirement
+	echo "google-api-core <= 2.8.2" >> requirements.in
+
 	# This will take the requirements.in file and generate a file
 	# requirements.txt with the hashes for the required packages
 	pip-compile --generate-hashes 2> /dev/null


### PR DESCRIPTION
This will be reverted once barman removes the 'protobuf<3.18' requirement

Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>