### PR TITLE
chore: fix package discrepancies

### DIFF
--- a/.github/generate-strategy.sh
+++ b/.github/generate-strategy.sh
@@ -77,7 +77,7 @@ for version in "${ubi_versions[@]}"; do
 
 	# Read versions from the definition file
 	versionFile="${version}/.versions.json"
-	fullVersion=$(jq -r '.POSTGRES_VERSION | split("-") | .[0]' "${versionFile}")
+	fullVersion=$(jq -r '.POSTGRES_VERSION' "${versionFile}")
 	releaseVersion=$(jq -r '.IMAGE_RELEASE_VERSION' "${versionFile}")
 
 	# Initial aliases are "major version", "optional alias", "full version with release"
@@ -133,8 +133,8 @@ for version in "${ubi_versions[@]}"; do
 
 	# Read versions from the definition file
 	versionFile="${version}/.versions-postgis.json"
-	fullVersion=$(jq -r '.POSTGRES_VERSION | split("-") | .[0]' "${versionFile}")
-	postgisVersion=$(jq -r '.POSTGIS_VERSION | split("-") | .[0]' "${versionFile}" | cut -f1,2 -d.)
+	fullVersion=$(jq -r '.POSTGRES_VERSION' "${versionFile}")
+	postgisVersion=$(jq -r '.POSTGIS_VERSION' "${versionFile}" | cut -f1,2 -d.)
 	releaseVersion=$(jq -r '.IMAGE_RELEASE_VERSION' "${versionFile}")
 
 	# Initial aliases are "major version", "optional alias", "full version with release"

--- a/UBI/update.sh
+++ b/UBI/update.sh
@@ -71,7 +71,7 @@ get_postgresql_version() {
 
 	if [[ "${pgArchMatrix[$arch]}" == "pgdg" ]]; then
 		latest_pg_version=$(curl -fsSL "${base_url}/${pg_major}/redhat/rhel-${os_version}-${arch}/" | \
-			perl -ne '/<a.*href="postgresql'"${pg_major}"'-server-([^"]+).'"${arch}"'.rpm"/ && print "$1\n"' | \
+			perl -ne '/<a.*href="postgresql'"${pg_major}"'-server-([^"]+)-\d+.*.'"${arch}"'.rpm"/ && print "$1\n"' | \
 			sort -rV | head -n1)
 	fi
 
@@ -94,7 +94,7 @@ check_cloudsmith_pkgs() {
 
 	cloudsmith ls pkgs enterprisedb/"${repo}" -q "name:postgresql*-server$ distribution:el/${os_version} version:latest architecture:${arch}" -F json 2> /dev/null | \
 			jq '.data[].filename' | \
-			sed -n 's/.*postgresql'"${pg_major}"'-server-\([0-9].*\)\.'"${arch}"'.*/\1/p' | \
+			sed -n 's/.*postgresql'"${pg_major}"'-server-\([0-9]\+.[0-9]\+\)-.*\.'"${arch}"'.*/\1/p' | \
 			sort -V
 }
 
@@ -143,11 +143,11 @@ get_postgis_version() {
 	local pg_major="$1"; shift
 
 	local base_url="https://yum.postgresql.org"
-	local regexp='postgis\d+_'"${pg_major}"'-([\d+\.]+-\d+.rhel'"${os_version}"').'"${arch}"'.rpm'
+	local regexp='postgis\d+_'"${pg_major}"'-(\d+.\d+.\d+)-\d+.rhel'"${os_version}"'.'"${arch}"'.rpm'
 
 	if [ "$pg_major" -gt '15' ]; then
 		base_url="$base_url/testing"
-		regexp='postgis\d+_'"${pg_major}"'-([\d+\.]+-.*.rhel'"${os_version}"').'"${arch}"'.rpm'
+		regexp='postgis\d+_'"${pg_major}"'-(\d+.\d+.\d+)-.*.rhel'"${os_version}"'.'"${arch}"'.rpm'
 	fi
 
 	postgisVersion=$(curl -fsSL "${base_url}/${pg_major}/redhat/rhel-${os_version}-${arch}/" | \


### PR DESCRIPTION
This problem arises because there's no guarantee pkgs built by EDB and PGDG have the same package version.
We also have no guarantee that a certain package version is available for all the architectures involved, because a new pkg version release may be done just for a specific arch. This makes our current way of fetching packages unreliable and prone to discrepancies errors (which are preemptively catched during the update.sh script).

The purpose of this patch is to avoid selecting a package version and automatically let the package manager
pick the latest one for the current architecture at build time.
Thus, we also avoid saving the package distribution in the JSON version file.